### PR TITLE
ALLOW NONSTANDART PREFIXES (only if True in .cfg Settings -> allow_nonstandart_prefixes)

### DIFF
--- a/hikka/dispatcher.py
+++ b/hikka/dispatcher.py
@@ -286,7 +286,7 @@ class CommandDispatcher:
 
         if (
             message.out
-            and len(message.message) > 2
+            and len(message.message) > len(prefix) * 2
             and (
                 message.message.startswith(prefix * 2)
                 and any(s != prefix for s in message.message)
@@ -297,7 +297,7 @@ class CommandDispatcher:
             # Allow escaping commands using .'s
             if not watcher:
                 await message.edit(
-                    message.message[1:],
+                    message.message[len(prefix):],
                     parse_mode=lambda s: (
                         s,
                         utils.relocate_entities(message.entities, -1, message.message)
@@ -342,12 +342,12 @@ class CommandDispatcher:
         ):
             return False
 
-        if not message.message or len(message.message) == 1:
+        if not message.message or len(message.message) == len(prefix):
             return False  # Message is just the prefix
 
         initiator = getattr(event, "sender_id", 0)
 
-        command = message.message[1:].strip().split(maxsplit=1)[0]
+        command = message.message[len(prefix):].strip().split(maxsplit=1)[0]
         tag = command.split("@", maxsplit=1)
 
         if len(tag) == 2:

--- a/hikka/modules/settings.py
+++ b/hikka/modules/settings.py
@@ -19,6 +19,16 @@ class CoreMod(loader.Module):
 
     strings = {"name": "Settings"}
 
+    def __init__(self):
+        self.config = loader.ModuleConfig(
+            loader.ConfigValue(
+                "allow_nonstandart_prefixes",
+                False,
+                "Allow non-standard prefixes like premium emojis or multi-symbol prefixes",
+                validator=loader.validators.Boolean(),
+            ),
+        )
+
     async def blacklistcommon(self, message: Message):
         args = utils.get_args(message)
 
@@ -138,7 +148,7 @@ class CoreMod(loader.Module):
             await utils.answer(message, self.strings("what_prefix"))
             return
 
-        if len(args) != 1:
+        if len(args) != 1 and self.config.get("allow_nonstandart_prefixes") is False:
             await utils.answer(message, self.strings("prefix_incorrect"))
             return
 
@@ -157,7 +167,7 @@ class CoreMod(loader.Module):
             message,
             self.strings("prefix_set").format(
                 "<emoji document_id=5197474765387864959>👍</emoji>",
-                newprefix=utils.escape_html(args[0]),
+                newprefix=utils.escape_html(args),
                 oldprefix=utils.escape_html(oldprefix),
             ),
         )


### PR DESCRIPTION
ALLOW NONSTANDART PREFIXES (only if True in .cfg Settings -> allow_nonstandart_prefixes)